### PR TITLE
Added extra check for preventing warning when file is deleted between -f and -s tests

### DIFF
--- a/lib/Filesys/DiskUsage.pm
+++ b/lib/Filesys/DiskUsage.pm
@@ -217,8 +217,11 @@ sub du {
       }
     }
     elsif (-f) { # is a file
-      $sizes{$_}  = $config{'sector-size'} - 1 + -s;
-      $sizes{$_} -= $sizes{$_} % $config{'sector-size'};
+      my $file_size = -s;
+      if (defined $file_size) {
+        $sizes{$_}  = $config{'sector-size'} - 1 + $file_size;
+        $sizes{$_} -= $sizes{$_} % $config{'sector-size'};
+      }
     }
     elsif (-d) { # is a directory
       if ($config{recursive} && $config{'max-depth'}) {


### PR DESCRIPTION
When using Filesys::Diskusage::du for directories with lots of deletions sometimes you can get the warning:
`Use of uninitialized value in addition (+) at C:/strawberry/perl/site/lib/Filesys/DiskUsage.pm line 220`
This happens because the -f test pass but before -s the file is deleted, so -s returns undef.

This pull request add an extra check to avoid the warning.

Sorry but I can't make a test because file test operators can't be mocked, as far as I know.